### PR TITLE
includemocs - allow to open ISO-8859-1 files

### DIFF
--- a/qt/includemocs/includemocs.py
+++ b/qt/includemocs/includemocs.py
@@ -75,7 +75,7 @@ regexp = re.compile("\\s*(Q_OBJECT|Q_GADGET|Q_NAMESPACE)\\s*")
 
 
 def hasMacro(fileName):
-    with open(fileName, "r", encoding="utf8") as fileHandle:
+    with open(fileName, "r", encoding="ISO-8859-1") as fileHandle:
         for line in fileHandle:
             if regexp.match(line):
                 return True


### PR DESCRIPTION
My project has files containing non-utf-8 characters.
This fix allows such files to be opened without hitting an exception in the open() call.

for example:
"Copyright <A9> Microsoft Corp."
and
"<95> Redistributions of source code must retain the above copyright notice,"
