### PR TITLE
Standardize project to KDAB copyright policy

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -5,22 +5,22 @@ Source: http://github.com/KDABLabs/KDToolBox
 
 #misc source code
 Files: qt/stringtokenizer/include/QStringTokenizer qt/stringtokenizer/include/QtCore/QStringTokenizer *.qrc *.json *.ui
-Copyright: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: MIT
 
 #misc documentation
 Files: *.md
-Copyright: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: MIT
 
 #misc config files
 Files: .clang-format .clazy .cmake-format.py .codespellrc .gitignore .gitmodules .gitreview .krazy .pep8 .pre-commit-config.yaml .pylintrc .qmake.conf .travis.yml appveyor.yml .mdlrc .mdlrc.rb
-Copyright: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: MIT
 
 #artwork
 Files: *.png
-Copyright: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: MIT
 
 #3rdparty fmt

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-KDToolBox is (C) 2019-2023, Klarälvdalens Datakonsult AB (KDAB) and is
-made available under the terms of the MIT license (see LICENSES/MIT.txt).
+KDToolBox is © Klarälvdalens Datakonsult AB (KDAB) and is made available
+under the terms of the MIT license (see LICENSES/MIT.txt).
 
 Contact KDAB at <info@kdab.com> to inquire about commercial licensing.

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ KDAB's collection of miscellaneous useful C++ classes and stuff.
 
 ## Licensing
 
-KDToolBox is (C) 2019-2023, Klarälvdalens Datakonsult AB (KDAB) and is
-made available under the terms of the [MIT](LICENSES/MIT.txt) license.
+KDToolBox is © Klarälvdalens Datakonsult AB (KDAB) and is made available
+under the terms of the [MIT](LICENSES/MIT.txt) license.
 
 Contact KDAB at <info@kdab.com> if you need different licensing options.
 

--- a/cmake/modules/CheckSubmoduleExists.cmake
+++ b/cmake/modules/CheckSubmoduleExists.cmake
@@ -1,7 +1,8 @@
+# This file is part of KDToolBox.
 #
-# SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: MIT
 #
 
 # Submodule handling

--- a/config.tests/cpp20/cpp20.cpp
+++ b/config.tests/cpp20/cpp20.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/cpp/duplicatetracker/include/duplicatetracker.h
+++ b/cpp/duplicatetracker/include/duplicatetracker.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Marc Mutz <marc.mutz@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/cpp/duplicatetracker/tests/duplicatetracker/tst_duplicatetracker.cpp
+++ b/cpp/duplicatetracker/tests/duplicatetracker/tst_duplicatetracker.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Marc Mutz <marc.mutz@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/cpp/future-backports/include/k20/deque.h
+++ b/cpp/future-backports/include/k20/deque.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Marc Mutz <marc.mutz@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/cpp/future-backports/include/k20/detail/erase_if.h
+++ b/cpp/future-backports/include/k20/detail/erase_if.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/cpp/future-backports/include/k20/forward_list.h
+++ b/cpp/future-backports/include/k20/forward_list.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Marc Mutz <marc.mutz@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/cpp/future-backports/include/k20/list.h
+++ b/cpp/future-backports/include/k20/list.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Marc Mutz <marc.mutz@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/cpp/future-backports/include/k20/map.h
+++ b/cpp/future-backports/include/k20/map.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Marc Mutz <marc.mutz@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/cpp/future-backports/include/k20/set.h
+++ b/cpp/future-backports/include/k20/set.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Marc Mutz <marc.mutz@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/cpp/future-backports/include/k20/string.h
+++ b/cpp/future-backports/include/k20/string.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Marc Mutz <marc.mutz@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/cpp/future-backports/include/k20/unordered_map.h
+++ b/cpp/future-backports/include/k20/unordered_map.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Marc Mutz <marc.mutz@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/cpp/future-backports/include/k20/unordered_set.h
+++ b/cpp/future-backports/include/k20/unordered_set.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Marc Mutz <marc.mutz@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/cpp/future-backports/include/k20/vector.h
+++ b/cpp/future-backports/include/k20/vector.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Marc Mutz <marc.mutz@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/cpp/future-backports/tests/k20/erase_if/tst_erase_if.cpp
+++ b/cpp/future-backports/tests/k20/erase_if/tst_erase_if.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/cpp/propagate_const/propagate_const.h
+++ b/cpp/propagate_const/propagate_const.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2022-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/cpp/propagate_const/test/tst_propagate_const.cpp
+++ b/cpp/propagate_const/test/tst_propagate_const.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/cpp/toContainer/toContainer.h
+++ b/cpp/toContainer/toContainer.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/cpp/toContainer/tst_toContainer.cpp
+++ b/cpp/toContainer/tst_toContainer.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/general/asan_assert_fail/asan_assert_fail.c
+++ b/general/asan_assert_fail/asan_assert_fail.c
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Milian Wolff <milian.wolff@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/KDSignalThrottler/examples/debouncedSearch/main.cpp
+++ b/qt/KDSignalThrottler/examples/debouncedSearch/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/KDSignalThrottler/examples/signalThrottlersDemo/main.cpp
+++ b/qt/KDSignalThrottler/examples/signalThrottlersDemo/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/KDSignalThrottler/src/KDSignalThrottler.cpp
+++ b/qt/KDSignalThrottler/src/KDSignalThrottler.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/KDSignalThrottler/src/KDSignalThrottler.h
+++ b/qt/KDSignalThrottler/src/KDSignalThrottler.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/KDSignalThrottler/test/tst_KDSignalThrottler.cpp
+++ b/qt/KDSignalThrottler/test/tst_KDSignalThrottler.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/KDSqlDatabaseTransaction/KDSqlDatabaseTransaction.h
+++ b/qt/KDSqlDatabaseTransaction/KDSqlDatabaseTransaction.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/KDSqlDatabaseTransaction/test/tst_KDSqlDatabaseTransaction.cpp
+++ b/qt/KDSqlDatabaseTransaction/test/tst_KDSqlDatabaseTransaction.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/asan_assert_fail_qt/asan_assert_fail_qt.cpp
+++ b/qt/asan_assert_fail_qt/asan_assert_fail_qt.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Milian Wolff <milian.wolff@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/cmake-project/cmake-project
+++ b/qt/cmake-project/cmake-project
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SPDX-FileCopyrightText: 2020-2023 Klaravdalens Datakonsult AB (KDAB), author David Faure <david.faure@kdab.com>
+# SPDX-FileCopyrightText: 2020 Klaravdalens Datakonsult AB (KDAB), author David Faure <david.faure@kdab.com>
 # SPDX-License-Identifier: MIT
 
 # Generate a CMakeLists.txt based on the .cpp files in the current directory

--- a/qt/dpiinfo.h
+++ b/qt/dpiinfo.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sérgio Martins <sergio.martins@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/eventfilter/eventfilter.h
+++ b/qt/eventfilter/eventfilter.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sérgio Martins <sergio.martins@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/eventfilter/example/main.cpp
+++ b/qt/eventfilter/example/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/includemocs/check-includemocs-hook.sh
+++ b/qt/includemocs/check-includemocs-hook.sh
@@ -1,6 +1,6 @@
 # This file is part of KDToolBox.
 #
-# SPDX-FileCopyrightText: 2022-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #

--- a/qt/includemocs/includemocs.py
+++ b/qt/includemocs/includemocs.py
@@ -1,43 +1,19 @@
+#!/usr/bin/env python3
+
+#
 # This file is part of KDToolBox.
 #
-# SPDX-FileCopyrightText: 2022-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# Author: Jesper K. Pedersen <jesper.pedersen@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #
-#! /usr/bin/env python3
 
 '''
 Script to add inclusion of mocs to files recursively.
 '''
 
 # pylint: disable=redefined-outer-name
-
-##########################################################################
-# MIT License
-#
-# Copyright (C) 2022-2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
-# Author: Jesper K. Pedersen <jesper.pedersen@kdab.com>
-#
-# This file is part of KDToolBox (https://github.com/KDAB/KDToolBox).
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, ** and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice (including the next paragraph)
-# shall be included in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF ** CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-# DEALINGS IN THE SOFTWARE.
-##########################################################################
 
 import os
 import re

--- a/qt/messagehandler/example/main.cpp
+++ b/qt/messagehandler/example/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/messagehandler/src/messagehandler.cpp
+++ b/qt/messagehandler/src/messagehandler.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/messagehandler/src/messagehandler.h
+++ b/qt/messagehandler/src/messagehandler.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/messagehandler/tests/messagehandler/tst_messagehandler.cpp
+++ b/qt/messagehandler/tests/messagehandler/tst_messagehandler.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Marc Mutz <marc.mutz@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/model_view/KDFunctionalSortFilterProxyModel/example/main.cpp
+++ b/qt/model_view/KDFunctionalSortFilterProxyModel/example/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/model_view/KDFunctionalSortFilterProxyModel/src/KDFunctionalSortFilterProxyModel.cpp
+++ b/qt/model_view/KDFunctionalSortFilterProxyModel/src/KDFunctionalSortFilterProxyModel.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/model_view/KDFunctionalSortFilterProxyModel/src/KDFunctionalSortFilterProxyModel.h
+++ b/qt/model_view/KDFunctionalSortFilterProxyModel/src/KDFunctionalSortFilterProxyModel.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/model_view/KDFunctionalSortFilterProxyModel/test/tst_kdfunctionalsortfilterproxymodel.cpp
+++ b/qt/model_view/KDFunctionalSortFilterProxyModel/test/tst_kdfunctionalsortfilterproxymodel.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/model_view/KDTableToListProxyModel/examples/countries/main.cpp
+++ b/qt/model_view/KDTableToListProxyModel/examples/countries/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/model_view/KDTableToListProxyModel/examples/countries/main.qml
+++ b/qt/model_view/KDTableToListProxyModel/examples/countries/main.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/model_view/KDTableToListProxyModel/src/KDTableToListProxyModel.cpp
+++ b/qt/model_view/KDTableToListProxyModel/src/KDTableToListProxyModel.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/model_view/KDTableToListProxyModel/src/KDTableToListProxyModel.h
+++ b/qt/model_view/KDTableToListProxyModel/src/KDTableToListProxyModel.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/model_view/KDTableToListProxyModel/tests/tst_kdtabletolistproxymodel.cpp
+++ b/qt/model_view/KDTableToListProxyModel/tests/tst_kdtabletolistproxymodel.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/model_view/ModelIterator/example/main.cpp
+++ b/qt/model_view/ModelIterator/example/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/model_view/ModelIterator/src/ModelIterator.cpp
+++ b/qt/model_view/ModelIterator/src/ModelIterator.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/model_view/ModelIterator/src/ModelIterator.h
+++ b/qt/model_view/ModelIterator/src/ModelIterator.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/model_view/sortProxyModel/sortproxymodel.cpp
+++ b/qt/model_view/sortProxyModel/sortproxymodel.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/model_view/sortProxyModel/sortproxymodel.h
+++ b/qt/model_view/sortProxyModel/sortproxymodel.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/model_view/sortProxyModel/test/tst_sortproxymodeltest.cpp
+++ b/qt/model_view/sortProxyModel/test/tst_sortproxymodeltest.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/model_view/sortProxyModel/test/vectormodel.h
+++ b/qt/model_view/sortProxyModel/test/vectormodel.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/model_view/updateableModel/UpdateableModel.h
+++ b/qt/model_view/updateableModel/UpdateableModel.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/model_view/updateableModel/example/Data.h
+++ b/qt/model_view/updateableModel/example/Data.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/model_view/updateableModel/example/MainWindow.cpp
+++ b/qt/model_view/updateableModel/example/MainWindow.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/model_view/updateableModel/example/MainWindow.h
+++ b/qt/model_view/updateableModel/example/MainWindow.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/model_view/updateableModel/example/main.cpp
+++ b/qt/model_view/updateableModel/example/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/model_view/updateableModel/example/tableModel.cpp
+++ b/qt/model_view/updateableModel/example/tableModel.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/model_view/updateableModel/example/tableModel.h
+++ b/qt/model_view/updateableModel/example/tableModel.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/notify_guard/src/notifyguard.cpp
+++ b/qt/notify_guard/src/notifyguard.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/notify_guard/src/notifyguard.h
+++ b/qt/notify_guard/src/notifyguard.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/notify_guard/test/tst_notifyguard.cpp
+++ b/qt/notify_guard/test/tst_notifyguard.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/pointer_cast/pointer_cast.h
+++ b/qt/pointer_cast/pointer_cast.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/pointer_cast/test/tst_pointer_cast.cpp
+++ b/qt/pointer_cast/test/tst_pointer_cast.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/qml/PropertySelector/PropertySelector.cpp
+++ b/qt/qml/PropertySelector/PropertySelector.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/qml/PropertySelector/PropertySelector.h
+++ b/qt/qml/PropertySelector/PropertySelector.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: André Somers <andre.somers@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/qml/QmlStackTraceHelper/QmlStackTraceHelper.cpp
+++ b/qt/qml/QmlStackTraceHelper/QmlStackTraceHelper.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sérgio Martins <sergio.martins@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/qml/QmlStackTraceHelper/example/main.cpp
+++ b/qt/qml/QmlStackTraceHelper/example/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/qml/QmlStackTraceHelper/example/main.qml
+++ b/qt/qml/QmlStackTraceHelper/example/main.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/qt_fmt/qt_fmt.h
+++ b/qt/qt_fmt/qt_fmt.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/qt_fmt/test/tst_qt_fmt.cpp
+++ b/qt/qt_fmt/test/tst_qt_fmt.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/qt_hasher/qt_hasher.h
+++ b/qt/qt_hasher/qt_hasher.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/qt_hasher/test/tst_qt_hasher.cpp
+++ b/qt/qt_hasher/test/tst_qt_hasher.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/qt_hasher/test/tst_qt_hasher.h
+++ b/qt/qt_hasher/test/tst_qt_hasher.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/singleshot_connect/singleshot_connect.h
+++ b/qt/singleshot_connect/singleshot_connect.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/singleshot_connect/test/tst_singleshot_connect.cpp
+++ b/qt/singleshot_connect/test/tst_singleshot_connect.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/stringtokenizer/include/QtCore/qstringtokenizer.h
+++ b/qt/stringtokenizer/include/QtCore/qstringtokenizer.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/stringtokenizer/include/qstringtokenizer.h
+++ b/qt/stringtokenizer/include/qstringtokenizer.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Marc Mutz <marc.mutz@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/stringtokenizer/src/qstringtokenizer.cpp
+++ b/qt/stringtokenizer/src/qstringtokenizer.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Marc Mutz <marc.mutz@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/stringtokenizer/tests/qstringtokenizer/tst_qstringtokenizer.cpp
+++ b/qt/stringtokenizer/tests/qstringtokenizer/tst_qstringtokenizer.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: MIT
 */

--- a/qt/tabWindow/example/main.cpp
+++ b/qt/tabWindow/example/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Nicolas Arnaud-Cormos <nicolas.arnaud-cormos@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/tabWindow/src/tabwindow.cpp
+++ b/qt/tabWindow/src/tabwindow.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Nicolas Arnaud-Cormos <nicolas.arnaud-cormos@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/tabWindow/src/tabwindow.h
+++ b/qt/tabWindow/src/tabwindow.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2020-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2020 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Nicolas Arnaud-Cormos <nicolas.arnaud-cormos@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/ui_watchdog/example/main.cpp
+++ b/qt/ui_watchdog/example/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2017-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2017 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sérgio Martins <sergio.martins@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/qt/ui_watchdog/uiwatchdog.h
+++ b/qt/ui_watchdog/uiwatchdog.h
@@ -1,7 +1,7 @@
 /*
   This file is part of KDToolBox.
 
-  SPDX-FileCopyrightText: 2018-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2018 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sérgio Martins <sergio.martins@kdab.com>
 
   SPDX-License-Identifier: MIT

--- a/squish/kdrunsquish.py
+++ b/squish/kdrunsquish.py
@@ -1,32 +1,12 @@
+#!/usr/bin/env python3
+
+#
 # This file is part of KDToolBox.
 #
-# SPDX-FileCopyrightText: 2022-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2022 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 #
 # SPDX-License-Identifier: MIT
 #
-#!/usr/bin/env python3
-
-# MIT License
-
-# Copyright (C) 2022-2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
-
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE
 
 """
 This script runs squish tests in parallel via the Qt offscreen QPA


### PR DESCRIPTION
For individual files: use year of file creation
For entire project:
  remove year from the statement
  use the © where feasible

reference:
https://matija.suklje.name/how-and-why-to-properly-write-copyright-statements-in-your-code