### PR TITLE
sortproxymodel: check if source model is a proxy model

### DIFF
--- a/qt/model_view/sortProxyModel/sortproxymodel.cpp
+++ b/qt/model_view/sortProxyModel/sortproxymodel.cpp
@@ -133,6 +133,7 @@ void SortProxyModel::setSourceModel(QAbstractItemModel *model)
             connect(model, &QAbstractItemModel::dataChanged, this, &SortProxyModel::handleDataChanged);
             connect(model, &QAbstractItemModel::rowsInserted, this, &SortProxyModel::handleRowsInserted);
             connect(model, &QAbstractItemModel::rowsRemoved, this, &SortProxyModel::handleRowsRemoved);
+            connect(model, &QAbstractItemModel::modelReset, this, &SortProxyModel::handleModelReset);
         }
         endResetModel();
     }
@@ -552,6 +553,23 @@ void SortProxyModel::handleRowsRemoved(const QModelIndex &parent, int firstRemov
     m_invalidatedRows = make_pair(m_proxyToSourceMap.end(), m_proxyToSourceMap.end());
 
     buildReverseMap(m_proxyToSourceMap, m_sourceToProxyMap);
+}
+
+void SortProxyModel::handleModelReset()
+{
+    if (!sourceModel())
+        return;
+
+    const int sourceModelRowCount = sourceModel()->rowCount();
+    if (sourceModelRowCount > 0)
+    {
+        if (sourceModelRowCount != rowCount())
+            resetInternalData();
+
+        handleDataChanged(sourceModel()->index(0, 0),
+                          sourceModel()->index(sourceModel()->rowCount() - 1, 0),
+                          QList<int>());
+    }
 }
 
 /**

--- a/qt/model_view/sortProxyModel/sortproxymodel.h
+++ b/qt/model_view/sortProxyModel/sortproxymodel.h
@@ -82,6 +82,7 @@ private:
     void handleDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles);
     void handleRowsInserted(const QModelIndex &parent, int firstNewRow, int lastNewRow);
     void handleRowsRemoved(const QModelIndex &parent, int firstRemovedRow, int lastRemovedRow);
+    void handleModelReset();
 
     bool isInvalidedRow(const int row) const;
 


### PR DESCRIPTION
if the source model is a proxy model, the source model's source model might be changed and our SortProxyModel won't get notified. This might happen when we try to pass a QML-based proxy model as source model, like KDE Framework's `KItemModel.KSortFilterProxyModel` for example.