### PR TITLE
includemocs: include MOC file at the earliest possible opportunity if…

### DIFF
--- a/qt/includemocs/includemocs.py
+++ b/qt/includemocs/includemocs.py
@@ -93,6 +93,15 @@ def getMocInsertionLocation(filename, content):
     match = headerIncludeRegex.search(content)
     if match:
         return match.end()
+
+    # If we did not find #include of a current file, then it would be sufficient to #include a MOC file after all
+    # includes. This can happen if header file has different name from source file, or path to a header is not relative
+    # (e.g. /path/to/header.h instead of header.h).
+    headerIncludeRegex = re.compile(r'#include ".*?\.h"\n')
+    match = headerIncludeRegex.search(content)
+    if match:
+        return match.start()
+
     return 0
 
 


### PR DESCRIPTION
… header file is not found

The script expects to find header file include with relative path. However, if absolute path is used (e.g. #include "path/to/header.h" instead of #include "header.h") the check will return 0 as insertion position. This, however, can (and often will) conflict with license/copyright comment meaning MOC file will be included before license/copyright comment.

Furthermore, clang-format is unable to re-sort headers, if this check is enabled at all. And so, this means that user would have to manually adjust every file.

This patch add additional attempt at finding #include directive and if it is found, MOC file will be included before the first occurrence of the #include directive. This somewhat guarantees that license/copyright header has been skipped.

This change, of course, doesn't fix all the possible issues, but only attempts to mitigate a common instance of such case.