### PR TITLE
Fortify uses of std::min/max against Windows

### DIFF
--- a/cpp/duplicatetracker/include/duplicatetracker.h
+++ b/cpp/duplicatetracker/include/duplicatetracker.h
@@ -94,9 +94,9 @@ protected:
 
     explicit DuplicateTrackerBase(std::size_t numBuckets, const Hash &h, const Equal &e)
 #ifdef __cpp_lib_memory_resource
-        : Base(this->m_buffer, sizeof(this->m_buffer), std::max(numBuckets, Prealloc), h, e){}
+        : Base(this->m_buffer, sizeof(this->m_buffer), (std::max)(numBuckets, Prealloc), h, e){}
 #else
-        : Base(std::max(numBuckets, Prealloc), h, e)
+        : Base((std::max)(numBuckets, Prealloc), h, e)
     {
     }
 #endif

--- a/qt/KDStlContainerAdaptor/KDStlContainerAdaptor.h
+++ b/qt/KDStlContainerAdaptor/KDStlContainerAdaptor.h
@@ -275,7 +275,7 @@ struct StdVectorAdaptor : std::vector<T, Args...>
 
         if (len < 0)
             len = s;
-        len = std::min(len, s - pos);
+        len = (std::min)(len, s - pos);
 
         const auto b = this->begin() + pos;
         const auto e = b + len;


### PR DESCRIPTION
In public headers it's better to add parentheses around std::min/max because on Windows, these can be treated as the (in)famous min/max macros from Windows SDK (minwindef.h) if the user doesn't define NOMINMAX.