### PR TITLE
Avoid CMake deprecation warning about required version

### DIFF
--- a/qt/cmake-project/cmake-project
+++ b/qt/cmake-project/cmake-project
@@ -61,7 +61,7 @@ if [ "$QTVERSION" != "none" ]; then
 fi
 
 cat > CMakeLists.txt <<EOF
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.10)
 project($PROJECTNAME)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)


### PR DESCRIPTION
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.